### PR TITLE
Add error checking to init command

### DIFF
--- a/cmd/aem/commandInit.go
+++ b/cmd/aem/commandInit.go
@@ -32,9 +32,7 @@ func (p *commandInit) survey() string {
 
 	err := survey.Ask(surveyInitialQuestionsQuestions, &answers)
 
-	if nil != err && err.Error() == "interrupt" {
-		exitProgram("Interrupted config creation.\n")
-	}
+	validateSurveyInput(err)
 
 	if answers.JarLocationType == "filesystem" {
 		err = survey.Ask(surveyJarFileQuestions, &answers)
@@ -42,18 +40,14 @@ func (p *commandInit) survey() string {
 		err = survey.Ask(surveyJarHTTPQuestions, &answers)
 	}
 
-	if nil != err && err.Error() == "interrupt" {
-		exitProgram("Interrupted config creation.\n")
-	}
+	validateSurveyInput(err)
 
 	for {
-		survErr := survey.Ask(surveyAdditionalPackagesQuestions, &answers)
+		err = survey.Ask(surveyAdditionalPackagesQuestions, &answers)
 		answers.AdditionalPackages = append(answers.AdditionalPackages, answers.AdditionalPackage)
 		answers.AdditionalPackage = ""
 
-		if survErr != nil && survErr.Error() == "interrupt" {
-			exitProgram("Interrupted config creation.\n")
-		}
+		validateSurveyInput(err)
 		if !answers.MorePackages {
 			break
 		}
@@ -61,6 +55,17 @@ func (p *commandInit) survey() string {
 
 	return answers.getConfig()
 
+}
+
+//validateSurveyInput validates the returned error object from survey.Ask()
+func validateSurveyInput(err error) {
+	if nil != err {
+		if err.Error() == "interrupt" {
+			exitProgram("Interrupted: no config file created\n")
+		}
+		// exit with regular error (validation)
+		exitProgram(err.Error() + "\n")
+	}
 }
 
 func (p *commandInit) Execute(args []string) {

--- a/cmd/aem/commandInit.go
+++ b/cmd/aem/commandInit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/AlecAivazis/survey"
 	"github.com/pborman/getopt/v2"
 	"github.com/spf13/afero"
@@ -16,7 +17,6 @@ func newInitCommand() commandInit {
 		overwrite: false,
 	}
 }
-
 
 type commandInit struct {
 	u         *utility
@@ -68,7 +68,7 @@ func (p *commandInit) Execute(args []string) {
 		fmt.Printf("Written sample config file. please edit .aem\n")
 
 	} else {
-		exitProgram("\".aem\" file found; please edit to update the values.")
+		exitProgram("\".aem\" file found; please edit to update the values.\n")
 	}
 
 }

--- a/cmd/aem/commandInit.go
+++ b/cmd/aem/commandInit.go
@@ -30,18 +30,30 @@ func (p *commandInit) survey() string {
 	answers := newConfigAnswers()
 	answers.AdditionalPackages = []string{}
 
-	survey.Ask(surveyInitialQuestionsQuestions, &answers)
+	err := survey.Ask(surveyInitialQuestionsQuestions, &answers)
+
+	if nil != err && err.Error() == "interrupt" {
+		exitProgram("Interrupted config creation.\n")
+	}
 
 	if answers.JarLocationType == "filesystem" {
-		survey.Ask(surveyJarFileQuestions, &answers)
+		err = survey.Ask(surveyJarFileQuestions, &answers)
 	} else {
-		survey.Ask(surveyJarHTTPQuestions, &answers)
+		err = survey.Ask(surveyJarHTTPQuestions, &answers)
+	}
+
+	if nil != err && err.Error() == "interrupt" {
+		exitProgram("Interrupted config creation.\n")
 	}
 
 	for {
-		survey.Ask(surveyAdditionalPackagesQuestions, &answers)
+		survErr := survey.Ask(surveyAdditionalPackagesQuestions, &answers)
 		answers.AdditionalPackages = append(answers.AdditionalPackages, answers.AdditionalPackage)
 		answers.AdditionalPackage = ""
+
+		if survErr != nil && survErr.Error() == "interrupt" {
+			exitProgram("Interrupted config creation.\n")
+		}
 		if !answers.MorePackages {
 			break
 		}


### PR DESCRIPTION
Fixes #9 
Added an extra if statement to check if the error is equal to `interrupt`. This way other errors (validation etc) can be handled differently in the rest of the block underneath the nested if statement.